### PR TITLE
CTP-6045 Loosen the rule for Moodle assignments that requires both a start date and an end date for auto extension

### DIFF
--- a/classes/assessment/assessment.php
+++ b/classes/assessment/assessment.php
@@ -20,6 +20,7 @@ use core\clock;
 use core\di;
 use local_sitsgradepush\extension\ec;
 use local_sitsgradepush\extension\extension;
+use local_sitsgradepush\extension\models\raa_required_provisions;
 use local_sitsgradepush\extension\sora;
 use local_sitsgradepush\extensionmanager;
 use local_sitsgradepush\manager;
@@ -83,11 +84,6 @@ abstract class assessment implements iassessment {
      * @throws \moodle_exception
      */
     public function apply_extension(extension $extension): void {
-        $check = $this->is_valid_for_extension();
-        if (!$check->valid) {
-            throw new \moodle_exception($check->errorcode, 'local_sitsgradepush');
-        }
-
         // Skip extension if there is an extension added by exam guard.
         if ($this->has_exam_guard_extension()) {
             return;
@@ -266,19 +262,6 @@ abstract class assessment implements iassessment {
     }
 
     /**
-     * Check if the assessment is valid for EC or SORA extension.
-     *
-     * @return \stdClass
-     */
-    public function is_valid_for_extension(): \stdClass {
-        if ($this->get_start_date() === null || $this->get_end_date() === null) {
-            return $this->set_validity_result(false, 'error:assessmentdatesnotset');
-        }
-
-        return $this->set_validity_result(true);
-    }
-
-    /**
      * Delete SORA overrides for a mapping.
      * It is used to delete all SORA overrides for an assessment when the mapping is removed.
      *
@@ -415,10 +398,9 @@ abstract class assessment implements iassessment {
      * Check if assessment can apply SORA extension for a given SORA object and mapping id.
      *
      * @param sora $sora SORA extension object.
-     * @param int $mappingid SITS mapping ID.
      * @return bool
      */
-    public function can_assessment_apply_sora(sora $sora, int $mappingid): bool {
+    public function can_assessment_apply_sora(sora $sora): bool {
         // Check if extension feature is enabled.
         if (!extensionmanager::is_extension_enabled()) {
             return false;
@@ -431,6 +413,14 @@ abstract class assessment implements iassessment {
 
         // Skip SORA overrides if the end date of the assessment is in the past.
         if ($this->get_end_date() < $this->clock->time()) {
+            return false;
+        }
+
+        // If RAA extension type is time per hour, start date and end date are required to be set to calculate the duration.
+        if (
+            $sora->raarequiredprovisions->get_extension_type() === raa_required_provisions::EXTENSION_TIME_PER_HOUR
+            && (empty($this->get_start_date()) || empty($this->get_end_date()))
+        ) {
             return false;
         }
 

--- a/classes/extension/sora.php
+++ b/classes/extension/sora.php
@@ -235,7 +235,7 @@ class sora extends extension {
                 $assessment = assessmentfactory::get_assessment($mapping->sourcetype, $mapping->sourceid);
 
                 // Check if the assessment can apply SORA extension.
-                if (!$assessment->can_assessment_apply_sora($this, $mapping->id)) {
+                if (!$assessment->can_assessment_apply_sora($this)) {
                     continue;
                 }
 

--- a/classes/extensionmanager.php
+++ b/classes/extensionmanager.php
@@ -218,9 +218,7 @@ class extensionmanager {
      * @return bool
      */
     public static function is_source_extension_eligible(assessment $assessment, bool $duedatecheck = true): bool {
-        $primarycheck = self::is_extension_enabled() &&
-            $assessment->is_extension_supported() &&
-            $assessment->is_valid_for_extension()->valid;
+        $primarycheck = self::is_extension_enabled() && $assessment->is_extension_supported();
 
         return $duedatecheck ? $primarycheck && $assessment->get_end_date() > di::get(clock::class)->time() : $primarycheck;
     }

--- a/tests/extension/raa/raa_assign_test.php
+++ b/tests/extension/raa/raa_assign_test.php
@@ -138,6 +138,43 @@ final class raa_assign_test extends raa_base {
     }
 
     /**
+     * Test an assignment without a start date can be extended using hours extension type (e.g. HD05).
+     *
+     * @covers \local_sitsgradepush\assessment\assessment::can_assessment_apply_sora
+     * @covers \local_sitsgradepush\assessment\assign::apply_sora_extension
+     * @return void
+     */
+    public function test_assignment_without_start_date_can_be_extended_with_hours_type(): void {
+        // Create an assignment with no start date mapped to HD05.
+        $assign = $this->setup_assignment_with_mapping($this->course1->id, null, '2025-02-18 14:00:00', 'PUBL0065A7PG', '001');
+
+        // Process all mappings for SORA.
+        $this->process_all_mappings_for_sora();
+
+        // Verify the override was created - HD05 extends by 14 hours.
+        $this->assert_assignment_override_exists(new sora(), $assign, 14 * HOURSECS, strtotime('2025-02-19 04:00:00'));
+    }
+
+    /**
+     * Test an assignment without a start date cannot be extended using time per hour extension type (e.g. ED03).
+     *
+     * @covers \local_sitsgradepush\assessment\assessment::can_assessment_apply_sora
+     * @return void
+     */
+    public function test_assignment_without_start_date_cannot_be_extended_with_time_per_hour_type(): void {
+        global $DB;
+
+        // Create an assignment with no start date mapped to ED03 (time per hour - requires start date).
+        $assign = $this->setup_assignment_with_mapping($this->course1->id, null, '2025-02-11 13:00:00', 'LAWS0024A6UF', '001');
+
+        // Process all mappings for SORA.
+        $this->process_all_mappings_for_sora();
+
+        // Verify no override was created - time per hour extension requires start date.
+        $this->assertFalse($DB->get_record('assign_overrides', ['assignid' => $assign->id]));
+    }
+
+    /**
      * Test the update RAA override for students in a mapping.
      * It also tests the RAA override using the student data from assessment API
      * and the RAA override group is deleted when the mapping is removed.
@@ -479,7 +516,7 @@ final class raa_assign_test extends raa_base {
      * Create assignment and mapping for testing.
      *
      * @param int $courseid The course ID.
-     * @param string $startdatetime Start datetime string.
+     * @param string|null $startdatetime Start datetime string, or null for no start date.
      * @param string $enddatetime End datetime string.
      * @param string $mapcode MAB mapcode.
      * @param string $mabseq MAB sequence.
@@ -490,7 +527,7 @@ final class raa_assign_test extends raa_base {
      */
     private function setup_assignment_with_mapping(
         int $courseid,
-        string $startdatetime,
+        ?string $startdatetime,
         string $enddatetime,
         string $mapcode,
         string $mabseq,
@@ -498,8 +535,8 @@ final class raa_assign_test extends raa_base {
     ): \stdClass {
         global $DB;
 
-        $startdate = $this->clock->now()->modify($startdatetime)->getTimestamp();
-        $enddate = $this->clock->now()->modify($enddatetime)->getTimestamp();
+        $startdate = $startdatetime ? strtotime($startdatetime) : 0;
+        $enddate = strtotime($enddatetime);
         $assign = $this->create_assignment($courseid, $startdate, $enddate);
 
         $mab = $DB->get_record('local_sitsgradepush_mab', ['mapcode' => $mapcode, 'mabseq' => $mabseq]);


### PR DESCRIPTION
- Removed invalid start date and end date check
- Added phpunit tests to verify Moodle assignment without start date can be extended