### PR TITLE
CTP-6372 Add durable student-to-SITS-delivery resolution service

### DIFF
--- a/classes/cachemanager.php
+++ b/classes/cachemanager.php
@@ -47,6 +47,9 @@ class cachemanager {
     /** @var string Cache area for storing student candidate numbers.*/
     const CACHE_AREA_CANDIDATE_NUMBERS = 'candidatenumbers';
 
+    /** @var string Cache area for the "student resolved to no delivery" negative marker.*/
+    const CACHE_AREA_DELIVERYRESOLUTION = 'deliveryresolution';
+
     /**
      * Get cache.
      *

--- a/classes/delivery/db_student_delivery_store.php
+++ b/classes/delivery/db_student_delivery_store.php
@@ -1,0 +1,81 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_sitsgradepush\delivery;
+
+use core\clock;
+use core\di;
+use local_sitsgradepush\delivery\models\delivery_key;
+
+/**
+ * Stores resolved student to delivery mappings in the durable database table.
+ *
+ * @package    local_sitsgradepush
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ */
+class db_student_delivery_store {
+    /** @var string DB table for the durable student to module delivery mapping. */
+    const TABLE = 'local_sitsgradepush_stuenrol';
+
+    /**
+     * Get the delivery keys already stored for a student in a course.
+     *
+     * @param int $courseid
+     * @param int $userid
+     * @return delivery_key[]
+     */
+    public function find(int $courseid, int $userid): array {
+        global $DB;
+
+        $records = $DB->get_records(self::TABLE, ['courseid' => $courseid, 'userid' => $userid]);
+
+        return array_map(
+            fn($record) => delivery_key::from_record($record),
+            array_values($records),
+        );
+    }
+
+    /**
+     * Persist a student to delivery mapping, ignoring duplicates.
+     *
+     * @param int $courseid
+     * @param int $userid
+     * @param delivery_key $key
+     * @return void
+     */
+    public function save(int $courseid, int $userid, delivery_key $key): void {
+        global $DB;
+
+        $params = [
+            'courseid' => $courseid,
+            'userid' => $userid,
+            'modcode' => $key->modcode,
+            'modocc' => $key->modocc,
+            'academicyear' => $key->academicyear,
+            'periodslotcode' => $key->periodslotcode,
+        ];
+
+        if ($DB->record_exists(self::TABLE, $params)) {
+            return;
+        }
+
+        $record = (object) $params;
+        $record->timecreated = di::get(clock::class)->time();
+        $DB->insert_record(self::TABLE, $record);
+    }
+}

--- a/classes/delivery/delivery_service.php
+++ b/classes/delivery/delivery_service.php
@@ -1,0 +1,107 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_sitsgradepush\delivery;
+
+use local_sitsgradepush\delivery\models\delivery;
+use local_sitsgradepush\delivery\models\delivery_key;
+
+/**
+ * Public entry point for sourcing and resolving SITS module deliveries.
+ *
+ * Composes the delivery source, durable store and membership checker into a course-level reader
+ * and a cached student resolver. Callers depend on this thin facade; the wiring is an
+ * implementation detail. Use {@see self::create()} for the production wiring, or the constructor
+ * to inject collaborators (e.g. in tests).
+ *
+ * @package    local_sitsgradepush
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ */
+class delivery_service {
+    /** @var student_delivery_resolver Cached resolver composed from the injected collaborators. */
+    private readonly student_delivery_resolver $resolver;
+
+    /**
+     * Constructor.
+     *
+     * @param portico_delivery_source $source Source of the course's deliveries.
+     * @param db_student_delivery_store $store Durable store for resolved mappings.
+     * @param sits_membership_checker $membership Tests delivery membership.
+     */
+    public function __construct(
+        /** @var portico_delivery_source Source of the course's deliveries. */
+        private readonly portico_delivery_source $source,
+        db_student_delivery_store $store,
+        sits_membership_checker $membership,
+    ) {
+        $this->resolver = new student_delivery_resolver($source, $store, $membership);
+    }
+
+    /**
+     * Build the service with the production wiring.
+     *
+     * @return self
+     */
+    public static function create(): self {
+        return new self(
+            new portico_delivery_source(),
+            new db_student_delivery_store(),
+            new sits_membership_checker(),
+        );
+    }
+
+    /**
+     * Whether the delivery sourcing and resolution service is enabled.
+     *
+     * Acts as a kill switch: when disabled the service returns no deliveries.
+     *
+     * @return bool
+     */
+    public static function is_enabled(): bool {
+        return (bool) get_config('local_sitsgradepush', 'delivery_resolution_enabled');
+    }
+
+    /**
+     * Get the course's SITS module deliveries, each with its resolved components.
+     *
+     * @param int $courseid
+     * @return delivery[]
+     */
+    public function get_course_deliveries(int $courseid): array {
+        if (!self::is_enabled()) {
+            return [];
+        }
+
+        return $this->source->get_course_deliveries($courseid);
+    }
+
+    /**
+     * Resolve the deliveries a student belongs to, persisting newly resolved mappings.
+     *
+     * @param int $courseid
+     * @param int $userid
+     * @return delivery_key[]
+     */
+    public function resolve_student_deliveries(int $courseid, int $userid): array {
+        if (!self::is_enabled()) {
+            return [];
+        }
+
+        return $this->resolver->resolve($courseid, $userid);
+    }
+}

--- a/classes/delivery/models/delivery.php
+++ b/classes/delivery/models/delivery.php
@@ -1,0 +1,44 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_sitsgradepush\delivery\models;
+
+/**
+ * Immutable SITS module delivery with its assessment components.
+ *
+ * @package    local_sitsgradepush
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ */
+class delivery {
+    /**
+     * Constructor.
+     *
+     * @param delivery_key $key The delivery identity.
+     * @param string $name Human readable delivery name.
+     * @param delivery_component[] $components The delivery's assessment components.
+     */
+    public function __construct(
+        /** @var delivery_key The delivery identity. */
+        public readonly delivery_key $key,
+        /** @var string Human readable delivery name. */
+        public readonly string $name,
+        /** @var delivery_component[] The delivery's assessment components. */
+        public readonly array $components,
+    ) {
+    }
+}

--- a/classes/delivery/models/delivery_component.php
+++ b/classes/delivery/models/delivery_component.php
@@ -1,0 +1,56 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_sitsgradepush\delivery\models;
+
+/**
+ * Immutable assessment component of a SITS module delivery, with its resolved Moodle target.
+ *
+ * @package    local_sitsgradepush
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ */
+class delivery_component {
+    /**
+     * Constructor.
+     *
+     * @param int $mabid Local component grade (MAB) id.
+     * @param string $name Component name.
+     * @param string $mabseq Component sequence number.
+     * @param int|null $weight Component weighting as a percentage, or null when unknown.
+     * @param int|null $gradeitemid Resolved Moodle grade item id, or null when unmapped.
+     * @param int|null $cmid Resolved course module id for activity-backed components, or null.
+     * @param string|null $sourcetype Mapping source type, or null when unmapped.
+     */
+    public function __construct(
+        /** @var int Local component grade (MAB) id. */
+        public readonly int $mabid,
+        /** @var string Component name. */
+        public readonly string $name,
+        /** @var string Component sequence number */
+        public readonly string $mabseq,
+        /** @var int|null Component weighting as a percentage, or null when unknown. */
+        public readonly ?int $weight,
+        /** @var int|null Resolved Moodle grade item id, or null when unmapped. */
+        public readonly ?int $gradeitemid,
+        /** @var int|null Resolved course module id for activity-backed components, or null. */
+        public readonly ?int $cmid,
+        /** @var string|null Mapping source type, or null when unmapped. */
+        public readonly ?string $sourcetype,
+    ) {
+    }
+}

--- a/classes/delivery/models/delivery_key.php
+++ b/classes/delivery/models/delivery_key.php
@@ -1,0 +1,78 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_sitsgradepush\delivery\models;
+
+use stdClass;
+
+/**
+ * Immutable identity of a SITS module delivery.
+ *
+ * @package    local_sitsgradepush
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ */
+class delivery_key {
+    /**
+     * Constructor.
+     *
+     * @param string $modcode SITS module code.
+     * @param string $modocc Module occurrence.
+     * @param string $periodslotcode Period slot (PSL) code.
+     * @param string $academicyear Academic year (AYR) code.
+     */
+    public function __construct(
+        /** @var string SITS module code. */
+        public readonly string $modcode,
+        /** @var string Module occurrence. */
+        public readonly string $modocc,
+        /** @var string Period slot (PSL) code. */
+        public readonly string $periodslotcode,
+        /** @var string Academic year (AYR) code. */
+        public readonly string $academicyear,
+    ) {
+    }
+
+    /**
+     * Build a key from a durable student delivery mapping record.
+     *
+     * @param stdClass $record
+     * @return self
+     */
+    public static function from_record(stdClass $record): self {
+        return new self(
+            $record->modcode,
+            $record->modocc,
+            $record->periodslotcode,
+            $record->academicyear,
+        );
+    }
+
+    /**
+     * Stable string representation, suitable for grouping or array keys.
+     *
+     * @return string
+     */
+    public function key(): string {
+        return implode('-', [
+            $this->modcode,
+            $this->modocc,
+            $this->periodslotcode,
+            $this->academicyear,
+        ]);
+    }
+}

--- a/classes/delivery/portico_delivery_source.php
+++ b/classes/delivery/portico_delivery_source.php
@@ -1,0 +1,145 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_sitsgradepush\delivery;
+
+use block_portico_enrolments\manager as portico_manager;
+use local_sitsgradepush\assessment\assessmentfactory;
+use local_sitsgradepush\delivery\models\delivery;
+use local_sitsgradepush\delivery\models\delivery_component;
+use local_sitsgradepush\delivery\models\delivery_key;
+use local_sitsgradepush\manager;
+use moodle_exception;
+use stdClass;
+
+/**
+ * Sources course deliveries from portico module occurrences and local component grades.
+ *
+ * This adapter is the single seam that touches the external SITS systems. It degrades to an empty
+ * result when those systems are missing or unavailable, so the course page never fatals.
+ *
+ * @package    local_sitsgradepush
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ */
+class portico_delivery_source {
+    /**
+     * Get the course's SITS module deliveries, each with its resolved components.
+     *
+     * @param int $courseid
+     * @return delivery[]
+     */
+    public function get_course_deliveries(int $courseid): array {
+        $modocc = $this->get_modocc_mappings($courseid);
+        if (empty($modocc)) {
+            return [];
+        }
+
+        $manager = manager::get_manager();
+        $deliveries = [];
+        foreach ($manager->get_local_component_grades($modocc) as $moduledelivery) {
+            $key = new delivery_key(
+                $moduledelivery->modcode,
+                $moduledelivery->modocc,
+                $moduledelivery->periodslotcode,
+                $moduledelivery->academicyear,
+            );
+
+            $components = [];
+            foreach ($moduledelivery->componentgrades as $mab) {
+                $components[] = $this->build_component($courseid, $mab);
+            }
+
+            $deliveries[] = new delivery($key, $moduledelivery->modoccname, $components);
+        }
+
+        return $deliveries;
+    }
+
+    /**
+     * Build a delivery component from a local component grade (MAB), resolving its Moodle target.
+     *
+     * @param int $courseid
+     * @param stdClass $mab Local component grade record.
+     * @return delivery_component
+     */
+    private function build_component(int $courseid, stdClass $mab): delivery_component {
+        global $DB;
+
+        $mabid = (int) $mab->id;
+        $name = $mab->mabname;
+        $mabseq = $mab->mabseq;
+        $weight = isset($mab->mabperc) ? (int) $mab->mabperc : null;
+
+        // Find the non-reassessment mapping for this component grade in this course.
+        $mapping = $DB->get_record(manager::TABLE_ASSESSMENT_MAPPING, [
+            'courseid' => $courseid,
+            'componentgradeid' => $mab->id,
+            'reassessment' => 0,
+        ], 'id, sourcetype, sourceid');
+
+        if (!$mapping) {
+            return new delivery_component($mabid, $name, $mabseq, $weight, null, null, null);
+        }
+
+        $cmid = $mapping->sourcetype === assessmentfactory::SOURCETYPE_MOD ? (int) $mapping->sourceid : null;
+        $gradeitemid = $this->resolve_gradeitemid($mapping->sourcetype, (int) $mapping->sourceid);
+
+        return new delivery_component($mabid, $name, $mabseq, $weight, $gradeitemid, $cmid, $mapping->sourcetype);
+    }
+
+    /**
+     * Resolve the primary grade item id for a mapping's source, or null when unavailable.
+     *
+     * @param string $sourcetype
+     * @param int $sourceid
+     * @return int|null
+     */
+    private function resolve_gradeitemid(string $sourcetype, int $sourceid): ?int {
+        try {
+            $assessment = assessmentfactory::get_assessment($sourcetype, $sourceid);
+            $gradeitems = $assessment->get_grade_items();
+
+            if (empty($gradeitems)) {
+                return null;
+            }
+
+            return reset($gradeitems)->id;
+        } catch (moodle_exception $e) {
+            debugging($e->getMessage(), DEBUG_DEVELOPER);
+            return null;
+        }
+    }
+
+    /**
+     * Get the course's portico module occurrence mappings, degrading to an empty array.
+     *
+     * Treats an unavailable SITS database as "no deliveries" so callers never fatal when the
+     * external system is missing or down.
+     *
+     * @param int $courseid
+     * @return array
+     */
+    private function get_modocc_mappings(int $courseid): array {
+        try {
+            return portico_manager::get_modocc_mappings($courseid);
+        } catch (\Throwable $e) {
+            debugging($e->getMessage(), DEBUG_DEVELOPER);
+            return [];
+        }
+    }
+}

--- a/classes/delivery/sits_membership_checker.php
+++ b/classes/delivery/sits_membership_checker.php
@@ -1,0 +1,75 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_sitsgradepush\delivery;
+
+use local_sitsgradepush\delivery\models\delivery;
+use local_sitsgradepush\manager;
+use moodle_exception;
+
+/**
+ * Tests delivery membership by querying SITS for each of the delivery's components.
+ *
+ * @package    local_sitsgradepush
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ */
+class sits_membership_checker {
+    /**
+     * Whether the student belongs to the given delivery.
+     *
+     * @param int $userid
+     * @param delivery $delivery
+     * @return bool
+     */
+    public function is_member(int $userid, delivery $delivery): bool {
+        global $DB;
+
+        $manager = manager::get_manager();
+        foreach ($delivery->components as $component) {
+            $mab = $DB->get_record(manager::TABLE_COMPONENT_GRADE, ['id' => $component->mabid]);
+
+            if (!$mab) {
+                continue;
+            }
+
+            try {
+                // Check the first assessment component is enough, student is existed either in all of them or none of them.
+                $student = $manager->get_student_from_sits($mab, $userid);
+
+                // This assessment identifier contains the PSL code (Term) information, e.g. "12345678_1-2025-T1-0".
+                // As same SITS assessment component could be used for two module deliveries with just the term is different,
+                // the term information in the assessment identifier is the only way to tell a student
+                // is coming from which delivery currently.
+                if (empty($student['assessment']['identifier'])) {
+                    return false;
+                }
+
+                $pslcode = $manager->parse_pslcode_from_identifier($student['assessment']['identifier']);
+                if ($delivery->key->periodslotcode === $pslcode) {
+                    return true;
+                }
+
+                return false;
+            } catch (moodle_exception $e) {
+                debugging($e->getMessage(), DEBUG_DEVELOPER);
+            }
+        }
+
+        return false;
+    }
+}

--- a/classes/delivery/student_delivery_resolver.php
+++ b/classes/delivery/student_delivery_resolver.php
@@ -1,0 +1,126 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_sitsgradepush\delivery;
+
+use local_sitsgradepush\cachemanager;
+use local_sitsgradepush\delivery\models\delivery;
+use local_sitsgradepush\delivery\models\delivery_key;
+
+/**
+ * Resolves the SITS module deliveries a student belongs to, caching the outcome.
+ *
+ * A stored result is served from the durable store without recomputing; on a miss the live source
+ * and membership checker are consulted and the result is persisted. Stored mappings are never
+ * auto-deleted, so they survive SITS later dropping the student.
+ *
+ * A resolution that finds no delivery persists nothing, so it cannot be cached in the durable store.
+ * To avoid calling the membership API on every page visit for such a student, an empty result is
+ * remembered in a short-lived negative cache and re-checked once the cache expires.
+ *
+ * @package    local_sitsgradepush
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ */
+class student_delivery_resolver {
+    /** @var int Seconds a "no delivery" result is trusted before the API is consulted again. */
+    private const NEGATIVE_TTL = DAYSECS;
+
+    /**
+     * Constructor.
+     *
+     * @param portico_delivery_source $source Source of the course's deliveries.
+     * @param db_student_delivery_store $store Durable store to read and write.
+     * @param sits_membership_checker $membership Tests delivery membership.
+     */
+    public function __construct(
+        /** @var portico_delivery_source Source of the course's deliveries. */
+        private readonly portico_delivery_source $source,
+        /** @var db_student_delivery_store Durable store to read and write. */
+        private readonly db_student_delivery_store $store,
+        /** @var sits_membership_checker Tests delivery membership. */
+        private readonly sits_membership_checker $membership,
+    ) {
+    }
+
+    /**
+     * Resolve the deliveries a student belongs to in a course, persisting newly resolved mappings.
+     *
+     * @param int $courseid
+     * @param int $userid
+     * @return delivery_key[]
+     */
+    public function resolve(int $courseid, int $userid): array {
+        $stored = $this->store->find($courseid, $userid);
+        if (!empty($stored)) {
+            return $stored;
+        }
+
+        $cachekey = $courseid . '_' . $userid;
+        // It was queried recently and found no delivery, so skip the API call and return empty.
+        if (cachemanager::get_cache(cachemanager::CACHE_AREA_DELIVERYRESOLUTION, $cachekey)) {
+            return [];
+        }
+
+        $deliveries = $this->source->get_course_deliveries($courseid);
+        if (empty($deliveries)) {
+            return [];
+        }
+
+        // Single-delivery course: the student necessarily belongs to the only delivery. Return it
+        // for use but do not persist, so only API-confirmed memberships are ever stored.
+        if (count($deliveries) === 1) {
+            return [reset($deliveries)->key];
+        }
+
+        $resolved = $this->resolve_live($deliveries, $userid);
+        foreach ($resolved as $key) {
+            $this->store->save($courseid, $userid, $key);
+        }
+
+        if (empty($resolved)) {
+            // Remember "no delivery" for the TTL so repeat page visits skip the get-students API.
+            cachemanager::set_cache(
+                cachemanager::CACHE_AREA_DELIVERYRESOLUTION,
+                $cachekey,
+                true,
+                self::NEGATIVE_TTL,
+            );
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Resolve which of the course's deliveries a student belongs to, via the SITS get-student API.
+     *
+     * @param delivery[] $deliveries The course's deliveries (guaranteed non-empty, count > 1).
+     * @param int $userid
+     * @return delivery_key[]
+     */
+    private function resolve_live(array $deliveries, int $userid): array {
+        // Find out student belongs to which deliveries.
+        $resolved = [];
+        foreach ($deliveries as $delivery) {
+            if ($this->membership->is_member($userid, $delivery)) {
+                $resolved[] = $delivery->key;
+            }
+        }
+
+        return $resolved;
+    }
+}

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -16,7 +16,15 @@
 
 namespace local_sitsgradepush\privacy;
 
+use context;
+use context_course;
 use core_privacy\local\metadata\collection;
+use core_privacy\local\request\approved_contextlist;
+use core_privacy\local\request\approved_userlist;
+use core_privacy\local\request\contextlist;
+use core_privacy\local\request\transform;
+use core_privacy\local\request\userlist;
+use core_privacy\local\request\writer;
 
 /**
  * Data provider class.
@@ -27,18 +35,9 @@ use core_privacy\local\metadata\collection;
  * @author     Alex Yeung <k.yeung@ucl.ac.uk>
  */
 class provider implements
-    \core_privacy\local\metadata\null_provider,
-    \core_privacy\local\metadata\provider {
-    /**
-     * Get the language string identifier with the component's language
-     * file to explain why this plugin stores no data.
-     *
-     * @return  string
-     */
-    public static function get_reason(): string {
-        return 'privacy:metadata';
-    }
-
+    \core_privacy\local\metadata\provider,
+    \core_privacy\local\request\core_userlist_provider,
+    \core_privacy\local\request\plugin\provider {
     /**
      * Returns metadata about this plugin.
      *
@@ -88,6 +87,155 @@ class provider implements
             'candidate_number' => 'privacy:metadata:local_sitsgradepush_scn:candidate_number',
         ], 'privacy:metadata:local_sitsgradepush_scn');
 
+        $collection->add_database_table('local_sitsgradepush_stuenrol', [
+            'courseid' => 'privacy:metadata:local_sitsgradepush_stuenrol:courseid',
+            'userid' => 'privacy:metadata:local_sitsgradepush_stuenrol:userid',
+            'modcode' => 'privacy:metadata:local_sitsgradepush_stuenrol:modcode',
+            'modocc' => 'privacy:metadata:local_sitsgradepush_stuenrol:modocc',
+            'academicyear' => 'privacy:metadata:local_sitsgradepush_stuenrol:academicyear',
+            'periodslotcode' => 'privacy:metadata:local_sitsgradepush_stuenrol:periodslotcode',
+        ], 'privacy:metadata:local_sitsgradepush_stuenrol');
+
         return $collection;
+    }
+
+    /**
+     * Get the list of contexts that contain user information for the specified user.
+     *
+     * @param int $userid The user to search.
+     * @return contextlist The contextlist containing the list of contexts used in this plugin.
+     */
+    public static function get_contexts_for_userid(int $userid): contextlist {
+        $contextlist = new contextlist();
+
+        $sql = "SELECT ctx.id
+                  FROM {local_sitsgradepush_stuenrol} se
+                  JOIN {context} ctx ON ctx.instanceid = se.courseid AND ctx.contextlevel = :contextlevel
+                 WHERE se.userid = :userid";
+        $contextlist->add_from_sql($sql, [
+            'contextlevel' => CONTEXT_COURSE,
+            'userid' => $userid,
+        ]);
+
+        return $contextlist;
+    }
+
+    /**
+     * Get the list of users who have data within a context.
+     *
+     * @param userlist $userlist The userlist containing the list of users who have data in this context.
+     * @return void
+     */
+    public static function get_users_in_context(userlist $userlist): void {
+        $context = $userlist->get_context();
+        if (!$context instanceof context_course) {
+            return;
+        }
+
+        $userlist->add_from_sql(
+            'userid',
+            "SELECT userid FROM {local_sitsgradepush_stuenrol} WHERE courseid = :courseid",
+            ['courseid' => $context->instanceid]
+        );
+    }
+
+    /**
+     * Export all user data for the specified user, in the specified contexts.
+     *
+     * @param approved_contextlist $contextlist The approved contexts to export information for.
+     * @return void
+     */
+    public static function export_user_data(approved_contextlist $contextlist): void {
+        global $DB;
+
+        $userid = $contextlist->get_user()->id;
+
+        foreach ($contextlist->get_contexts() as $context) {
+            if (!$context instanceof context_course) {
+                continue;
+            }
+
+            $records = $DB->get_records('local_sitsgradepush_stuenrol', [
+                'courseid' => $context->instanceid,
+                'userid' => $userid,
+            ]);
+            if (empty($records)) {
+                continue;
+            }
+
+            $deliveries = [];
+            foreach ($records as $record) {
+                $deliveries[] = (object) [
+                    'modcode' => $record->modcode,
+                    'modocc' => $record->modocc,
+                    'academicyear' => $record->academicyear,
+                    'periodslotcode' => $record->periodslotcode,
+                    'timecreated' => transform::datetime($record->timecreated),
+                ];
+            }
+
+            writer::with_context($context)->export_data(
+                [get_string('privacy:stuenrolpath', 'local_sitsgradepush')],
+                (object) ['deliveries' => $deliveries]
+            );
+        }
+    }
+
+    /**
+     * Delete all data for all users in the specified context.
+     *
+     * @param context $context The specific context to delete data for.
+     * @return void
+     */
+    public static function delete_data_for_all_users_in_context(context $context): void {
+        global $DB;
+
+        if (!$context instanceof context_course) {
+            return;
+        }
+
+        $DB->delete_records('local_sitsgradepush_stuenrol', ['courseid' => $context->instanceid]);
+    }
+
+    /**
+     * Delete all user data for the specified user, in the specified contexts.
+     *
+     * @param approved_contextlist $contextlist The approved contexts and user to delete information for.
+     * @return void
+     */
+    public static function delete_data_for_user(approved_contextlist $contextlist): void {
+        global $DB;
+
+        $userid = $contextlist->get_user()->id;
+
+        foreach ($contextlist->get_contexts() as $context) {
+            if (!$context instanceof context_course) {
+                continue;
+            }
+
+            $DB->delete_records('local_sitsgradepush_stuenrol', [
+                'courseid' => $context->instanceid,
+                'userid' => $userid,
+            ]);
+        }
+    }
+
+    /**
+     * Delete multiple users' data within a single context.
+     *
+     * @param approved_userlist $userlist The approved context and user information to delete information for.
+     * @return void
+     */
+    public static function delete_data_for_users(approved_userlist $userlist): void {
+        global $DB;
+
+        $context = $userlist->get_context();
+        if (!$context instanceof context_course) {
+            return;
+        }
+
+        [$insql, $inparams] = $DB->get_in_or_equal($userlist->get_userids(), SQL_PARAMS_NAMED);
+        $params = ['courseid' => $context->instanceid] + $inparams;
+        $DB->delete_records_select('local_sitsgradepush_stuenrol', "courseid = :courseid AND userid $insql", $params);
     }
 }

--- a/db/caches.php
+++ b/db/caches.php
@@ -51,4 +51,9 @@ $definitions = [
         'simplekeys' => true,
         'simpledata' => true,
     ],
+    'deliveryresolution' => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => true,
+        'simpledata' => true,
+    ],
 ];

--- a/db/install.xml
+++ b/db/install.xml
@@ -214,5 +214,25 @@
         <INDEX NAME="idx_academic_year" UNIQUE="false" FIELDS="academic_year"/>
       </INDEXES>
     </TABLE>
+    <TABLE NAME="local_sitsgradepush_stuenrol" COMMENT="Durable mapping of a student to their SITS module delivery">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Moodle user id"/>
+        <FIELD NAME="modcode" TYPE="char" LENGTH="12" NOTNULL="true" SEQUENCE="false" COMMENT="SITS module code"/>
+        <FIELD NAME="modocc" TYPE="char" LENGTH="6" NOTNULL="true" SEQUENCE="false" COMMENT="Module Occurrence"/>
+        <FIELD NAME="academicyear" TYPE="char" LENGTH="12" NOTNULL="true" SEQUENCE="false" COMMENT="Academic Year (AYR) code"/>
+        <FIELD NAME="periodslotcode" TYPE="char" LENGTH="6" NOTNULL="true" SEQUENCE="false" COMMENT="Period Slot (PSL) code"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="idx_delivery" TYPE="unique" FIELDS="courseid, userid, modcode, modocc, academicyear, periodslotcode"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="idx_courseid" UNIQUE="false" FIELDS="courseid"/>
+        <INDEX NAME="idx_userid" UNIQUE="false" FIELDS="userid"/>
+      </INDEXES>
+    </TABLE>
   </TABLES>
 </XMLDB>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -883,5 +883,40 @@ function xmldb_local_sitsgradepush_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026012700, 'local', 'sitsgradepush');
     }
 
+    if ($oldversion < 2026062900) {
+        // Define table local_sitsgradepush_stuenrol to be created.
+        $table = new xmldb_table('local_sitsgradepush_stuenrol');
+
+        // Adding fields to table local_sitsgradepush_stuenrol.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('courseid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('modcode', XMLDB_TYPE_CHAR, '12', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('modocc', XMLDB_TYPE_CHAR, '6', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('academicyear', XMLDB_TYPE_CHAR, '12', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('periodslotcode', XMLDB_TYPE_CHAR, '6', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+
+        // Adding keys to table local_sitsgradepush_stuenrol.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key(
+            'idx_delivery',
+            XMLDB_KEY_UNIQUE,
+            ['courseid', 'userid', 'modcode', 'modocc', 'academicyear', 'periodslotcode']
+        );
+
+        // Adding indexes to table local_sitsgradepush_stuenrol.
+        $table->add_index('idx_courseid', XMLDB_INDEX_NOTUNIQUE, ['courseid']);
+        $table->add_index('idx_userid', XMLDB_INDEX_NOTUNIQUE, ['userid']);
+
+        // Conditionally launch create table for local_sitsgradepush_stuenrol.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Sitsgradepush savepoint reached.
+        upgrade_plugin_savepoint(true, 2026062900, 'local', 'sitsgradepush');
+    }
+
     return true;
 }

--- a/lang/en/local_sitsgradepush.php
+++ b/lang/en/local_sitsgradepush.php
@@ -28,6 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $string['cachedef_candidatenumbers'] = 'Student candidate numbers related data';
 $string['cachedef_componentgrades'] = 'SITS assessment components';
+$string['cachedef_deliveryresolution'] = 'Students resolved to no SITS module delivery';
 $string['cachedef_mappingmabinfo'] = 'SITS Mapping and MAB information';
 $string['cachedef_markingschemes'] = 'SITS marking schemes';
 $string['cachedef_studentspr'] = 'Student\'s SPR code per SITS assessment pattern';
@@ -221,7 +222,6 @@ $string['manualprocessextensions:success'] = 'Extension processing task has been
 $string['marks_transferred_successfully'] = 'Marks Transferred Successfully';
 $string['option:none'] = 'NONE';
 $string['pluginname'] = 'SITS Marks Transfer';
-$string['privacy:metadata'] = 'This plugin does not store any personal data.';
 $string['privacy:metadata:local_sitsgradepush_enrol'] = 'Stores the enrolment records temporarily for auto assessment due date extension.';
 $string['privacy:metadata:local_sitsgradepush_enrol:userid'] = 'The user who newly enrolled.';
 $string['privacy:metadata:local_sitsgradepush_err_log'] = 'Stores the error logs.';
@@ -239,6 +239,13 @@ $string['privacy:metadata:local_sitsgradepush_scn'] = 'Stores the student candid
 $string['privacy:metadata:local_sitsgradepush_scn:candidate_number'] = 'The candidate number assigned to the student.';
 $string['privacy:metadata:local_sitsgradepush_scn:student_code'] = 'The student code (ID number) of the user.';
 $string['privacy:metadata:local_sitsgradepush_scn:userid'] = 'The user whose candidate number is stored.';
+$string['privacy:metadata:local_sitsgradepush_stuenrol'] = 'Stores the resolved mapping of a student to their SITS module delivery.';
+$string['privacy:metadata:local_sitsgradepush_stuenrol:academicyear'] = 'The academic year (AYR) code of the delivery.';
+$string['privacy:metadata:local_sitsgradepush_stuenrol:courseid'] = 'The course the student belongs to.';
+$string['privacy:metadata:local_sitsgradepush_stuenrol:modcode'] = 'The SITS module code of the delivery.';
+$string['privacy:metadata:local_sitsgradepush_stuenrol:modocc'] = 'The module occurrence of the delivery.';
+$string['privacy:metadata:local_sitsgradepush_stuenrol:periodslotcode'] = 'The period slot (PSL) code of the delivery.';
+$string['privacy:metadata:local_sitsgradepush_stuenrol:userid'] = 'The user resolved to the delivery.';
 $string['privacy:metadata:local_sitsgradepush_tasks'] = 'Stores the transfer tasks.';
 $string['privacy:metadata:local_sitsgradepush_tasks:info'] = 'Additional information about the transfer task.';
 $string['privacy:metadata:local_sitsgradepush_tasks:status'] = 'The status of the transfer task.';
@@ -250,6 +257,7 @@ $string['privacy:metadata:local_sitsgradepush_tfr_log:response'] = 'The response
 $string['privacy:metadata:local_sitsgradepush_tfr_log:type'] = 'The type of the transfer task.';
 $string['privacy:metadata:local_sitsgradepush_tfr_log:userid'] = 'Whose this transfer task is for.';
 $string['privacy:metadata:local_sitsgradepush_tfr_log:usermodified'] = 'The user who requested the transfer task.';
+$string['privacy:stuenrolpath'] = 'SITS module delivery';
 $string['progress'] = 'Progress:';
 $string['pushrecordsexist'] = 'Transfer records exist';
 $string['pushrecordsnotexist'] = 'No transfer records';
@@ -300,6 +308,8 @@ $string['settings:deadlinegroupprefix:desc'] = 'Prefix used to identify teacher-
     ' Groups with this prefix will have their overwritten dates used as the base for RAA extension calculations.' .
     ' Leave empty to disable this feature and use the assessment\'s original deadline.';
 $string['settings:debug_error_logging'] = 'Enable debug error logging';
+$string['settings:delivery_resolution_enabled'] = 'Enable module delivery resolution';
+$string['settings:delivery_resolution_enabled:desc'] = 'Source SITS module deliveries and resolve which delivery a student belongs to.';
 $string['settings:enable'] = 'Enable Marks Transfer';
 $string['settings:enable:desc'] = 'Enable Marks Transfer to SITS';
 $string['settings:enableassesstypeupdate'] = 'Enable update local assessment type';

--- a/settings.php
+++ b/settings.php
@@ -219,6 +219,14 @@ if ($hassiteconfig) {
             '0'
         ));
 
+        // Setting to enable/disable the SITS module delivery sourcing and resolution service.
+        $settings->add(new admin_setting_configcheckbox(
+            'local_sitsgradepush/delivery_resolution_enabled',
+            get_string('settings:delivery_resolution_enabled', 'local_sitsgradepush'),
+            get_string('settings:delivery_resolution_enabled:desc', 'local_sitsgradepush'),
+            '1'
+        ));
+
         // Setting to configure the deadline group prefix.
         $settings->add(new admin_setting_configtext(
             'local_sitsgradepush/deadlinegroup_prefix',

--- a/tests/privacy_provider_test.php
+++ b/tests/privacy_provider_test.php
@@ -16,6 +16,12 @@
 
 namespace local_sitsgradepush;
 
+use context_course;
+use core_privacy\local\metadata\collection;
+use core_privacy\local\request\approved_contextlist;
+use core_privacy\local\request\approved_userlist;
+use core_privacy\local\request\userlist;
+use core_privacy\local\request\writer;
 use local_sitsgradepush\privacy\provider;
 
 /**
@@ -25,22 +31,228 @@ use local_sitsgradepush\privacy\provider;
  * @copyright  2023 onwards University College London {@link https://www.ucl.ac.uk/}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ * @covers     \local_sitsgradepush\privacy\provider
  */
 final class privacy_provider_test extends \advanced_testcase {
+    /**
+     * Set up the test.
+     *
+     * @return void
+     */
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
     }
 
     /**
-     * Test get_reason.
+     * The metadata collection describes the student enrolment delivery table.
      *
-     * @covers \local_sitsgradepush\privacy\provider::get_reason()
      * @return void
-     * @throws \coding_exception
      */
-    public function test_get_reason(): void {
-        $reason = get_string(provider::get_reason(), 'local_sitsgradepush');
-        $this->assertEquals('This plugin does not store any personal data.', $reason);
+    public function test_get_metadata(): void {
+        $collection = new collection('local_sitsgradepush');
+        $tables = [];
+        foreach (provider::get_metadata($collection)->get_collection() as $item) {
+            $tables[] = $item->get_name();
+        }
+        $this->assertContains('local_sitsgradepush_stuenrol', $tables);
+    }
+
+    /**
+     * The course context of every delivery a user belongs to is returned.
+     *
+     * @return void
+     */
+    public function test_get_contexts_for_userid(): void {
+        $courseone = $this->getDataGenerator()->create_course();
+        $coursetwo = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $other = $this->getDataGenerator()->create_user();
+
+        $this->create_delivery($courseone->id, $user->id);
+        $this->create_delivery($coursetwo->id, $user->id);
+        $this->create_delivery($courseone->id, $other->id);
+
+        $contextids = provider::get_contexts_for_userid($user->id)->get_contextids();
+        sort($contextids);
+        $expected = [context_course::instance($courseone->id)->id, context_course::instance($coursetwo->id)->id];
+        sort($expected);
+
+        $this->assertEquals($expected, $contextids);
+    }
+
+    /**
+     * Only users with a delivery in the given course context are listed.
+     *
+     * @return void
+     */
+    public function test_get_users_in_context(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $other = $this->getDataGenerator()->create_user();
+        $unrelated = $this->getDataGenerator()->create_user();
+
+        $this->create_delivery($course->id, $user->id);
+        $this->create_delivery($course->id, $other->id);
+
+        $context = context_course::instance($course->id);
+        $userlist = new userlist($context, 'local_sitsgradepush');
+        provider::get_users_in_context($userlist);
+
+        $userids = $userlist->get_userids();
+        sort($userids);
+        $expected = [$user->id, $other->id];
+        sort($expected);
+
+        $this->assertEquals($expected, $userids);
+        $this->assertNotContains($unrelated->id, $userids);
+    }
+
+    /**
+     * A user's delivery data is exported under the module delivery path.
+     *
+     * @return void
+     */
+    public function test_export_user_data(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+
+        $this->create_delivery($course->id, $user->id, 'COMP0001');
+        $this->create_delivery($course->id, $user->id, 'COMP0002');
+
+        $context = context_course::instance($course->id);
+        $contextlist = new approved_contextlist($user, 'local_sitsgradepush', [$context->id]);
+        provider::export_user_data($contextlist);
+
+        $writer = writer::with_context($context);
+        $this->assertTrue($writer->has_any_data());
+
+        $data = $writer->get_data([get_string('privacy:stuenrolpath', 'local_sitsgradepush')]);
+        $this->assertCount(2, $data->deliveries);
+
+        $modcodes = array_column($data->deliveries, 'modcode');
+        sort($modcodes);
+        $this->assertEquals(['COMP0001', 'COMP0002'], $modcodes);
+    }
+
+    /**
+     * Deleting all data for a context removes every delivery in that course only.
+     *
+     * @return void
+     */
+    public function test_delete_data_for_all_users_in_context(): void {
+        global $DB;
+
+        $courseone = $this->getDataGenerator()->create_course();
+        $coursetwo = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $other = $this->getDataGenerator()->create_user();
+
+        $this->create_delivery($courseone->id, $user->id);
+        $this->create_delivery($courseone->id, $other->id);
+        $this->create_delivery($coursetwo->id, $user->id);
+
+        provider::delete_data_for_all_users_in_context(context_course::instance($courseone->id));
+
+        $this->assertFalse($DB->record_exists('local_sitsgradepush_stuenrol', ['courseid' => $courseone->id]));
+        $this->assertTrue($DB->record_exists('local_sitsgradepush_stuenrol', ['courseid' => $coursetwo->id]));
+    }
+
+    /**
+     * Deleting data for a user removes only that user's deliveries in the approved contexts.
+     *
+     * @return void
+     */
+    public function test_delete_data_for_user(): void {
+        global $DB;
+
+        $courseone = $this->getDataGenerator()->create_course();
+        $coursetwo = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $other = $this->getDataGenerator()->create_user();
+
+        $this->create_delivery($courseone->id, $user->id);
+        $this->create_delivery($courseone->id, $other->id);
+        $this->create_delivery($coursetwo->id, $user->id);
+
+        $context = context_course::instance($courseone->id);
+        $contextlist = new approved_contextlist($user, 'local_sitsgradepush', [$context->id]);
+        provider::delete_data_for_user($contextlist);
+
+        $this->assertFalse($DB->record_exists('local_sitsgradepush_stuenrol', [
+            'courseid' => $courseone->id,
+            'userid' => $user->id,
+        ]));
+        $this->assertTrue($DB->record_exists('local_sitsgradepush_stuenrol', [
+            'courseid' => $courseone->id,
+            'userid' => $other->id,
+        ]));
+        $this->assertTrue($DB->record_exists('local_sitsgradepush_stuenrol', [
+            'courseid' => $coursetwo->id,
+            'userid' => $user->id,
+        ]));
+    }
+
+    /**
+     * Deleting data for a set of users removes only their deliveries in the given context.
+     *
+     * @return void
+     */
+    public function test_delete_data_for_users(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course();
+        $coursetwo = $this->getDataGenerator()->create_course();
+        $userone = $this->getDataGenerator()->create_user();
+        $usertwo = $this->getDataGenerator()->create_user();
+        $keep = $this->getDataGenerator()->create_user();
+
+        $this->create_delivery($course->id, $userone->id);
+        $this->create_delivery($course->id, $usertwo->id);
+        $this->create_delivery($course->id, $keep->id);
+        $this->create_delivery($coursetwo->id, $userone->id);
+
+        $context = context_course::instance($course->id);
+        $userlist = new approved_userlist($context, 'local_sitsgradepush', [$userone->id, $usertwo->id]);
+        provider::delete_data_for_users($userlist);
+
+        $this->assertFalse($DB->record_exists('local_sitsgradepush_stuenrol', [
+            'courseid' => $course->id,
+            'userid' => $userone->id,
+        ]));
+        $this->assertFalse($DB->record_exists('local_sitsgradepush_stuenrol', [
+            'courseid' => $course->id,
+            'userid' => $usertwo->id,
+        ]));
+        $this->assertTrue($DB->record_exists('local_sitsgradepush_stuenrol', [
+            'courseid' => $course->id,
+            'userid' => $keep->id,
+        ]));
+        $this->assertTrue($DB->record_exists('local_sitsgradepush_stuenrol', [
+            'courseid' => $coursetwo->id,
+            'userid' => $userone->id,
+        ]));
+    }
+
+    /**
+     * Insert a student delivery record for the given course and user.
+     *
+     * @param int $courseid The course id.
+     * @param int $userid The user id.
+     * @param string $modcode The SITS module code.
+     * @return int The inserted record id.
+     */
+    private function create_delivery(int $courseid, int $userid, string $modcode = 'COMP0001'): int {
+        global $DB;
+
+        return $DB->insert_record('local_sitsgradepush_stuenrol', (object) [
+            'courseid' => $courseid,
+            'userid' => $userid,
+            'modcode' => $modcode,
+            'modocc' => 'A6U',
+            'academicyear' => '2025',
+            'periodslotcode' => 'T1',
+            'timecreated' => 1710000000, // 2024-03-09 16:00:00 UTC.
+        ]);
     }
 }

--- a/tests/student_delivery_resolution_test.php
+++ b/tests/student_delivery_resolution_test.php
@@ -1,0 +1,233 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_sitsgradepush;
+
+use advanced_testcase;
+use local_sitsgradepush\delivery\db_student_delivery_store;
+use local_sitsgradepush\delivery\delivery_service;
+use local_sitsgradepush\delivery\models\delivery;
+use local_sitsgradepush\delivery\models\delivery_key;
+use local_sitsgradepush\delivery\portico_delivery_source;
+use local_sitsgradepush\delivery\sits_membership_checker;
+
+/**
+ * Tests for durable student to module delivery resolution.
+ *
+ * The delivery source and membership checker are stubbed (no SITS, no portico), while the durable
+ * store is the real database-backed store, so resolution, caching and persistence are exercised
+ * together against the test database.
+ *
+ * @package    local_sitsgradepush
+ * @category   test
+ * @coversDefaultClass \local_sitsgradepush\delivery\delivery_service
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ */
+final class student_delivery_resolution_test extends advanced_testcase {
+    /**
+     * A single-delivery course resolves without querying membership, but does not persist the result.
+     *
+     * @covers \local_sitsgradepush\delivery\student_delivery_resolver::resolve
+     * @return void
+     */
+    public function test_single_delivery_resolves_without_membership_check(): void {
+        $this->resetAfterTest();
+
+        $key = new delivery_key('LAWS0024', 'A6U', 'T1/2', '2025');
+        $source = $this->stub_source([new delivery($key, 'Law', [])]);
+        $store = new db_student_delivery_store();
+
+        // A single delivery is resolved without ever querying membership.
+        $checker = $this->createMock(sits_membership_checker::class);
+        $checker->expects($this->never())->method('is_member');
+
+        $service = new delivery_service($source, $store, $checker);
+        $resolved = $service->resolve_student_deliveries(11, 22);
+
+        $this->assertCount(1, $resolved);
+        $this->assertSame('LAWS0024-A6U-T1/2-2025', $resolved[0]->key());
+        // The assumed single delivery is not persisted: only API-confirmed memberships are stored.
+        $this->assertSame([], $store->find(11, 22));
+    }
+
+    /**
+     * A multi-delivery course resolves only the deliveries the student belongs to.
+     *
+     * @covers \local_sitsgradepush\delivery\student_delivery_resolver::resolve
+     * @return void
+     */
+    public function test_multi_delivery_resolves_via_membership(): void {
+        $this->resetAfterTest();
+
+        $keya = new delivery_key('LAWS0024', 'A6U', 'T1/2', '2025');
+        $keyb = new delivery_key('LAWS0099', 'A7P', 'T1/2', '2025');
+        $source = $this->stub_source([
+            new delivery($keya, 'Law A', []),
+            new delivery($keyb, 'Law B', []),
+        ]);
+        $store = new db_student_delivery_store();
+        // The student belongs only to delivery B.
+        $checker = $this->stub_checker([$keyb->key()]);
+
+        $service = new delivery_service($source, $store, $checker);
+        $resolved = $service->resolve_student_deliveries(11, 22);
+
+        $this->assertCount(1, $resolved);
+        $this->assertSame($keyb->key(), $resolved[0]->key());
+        // Only the delivery the student belongs to is persisted.
+        $stored = $store->find(11, 22);
+        $this->assertCount(1, $stored);
+        $this->assertSame($keyb->key(), $stored[0]->key());
+    }
+
+    /**
+     * An unresolved student returns an empty array and persists nothing.
+     *
+     * @covers \local_sitsgradepush\delivery\student_delivery_resolver::resolve
+     * @return void
+     */
+    public function test_unresolved_returns_empty_and_persists_nothing(): void {
+        // The empty-result path writes a negative marker to MUC, so isolate cache state.
+        $this->resetAfterTest();
+
+        $source = $this->stub_source([
+            new delivery(new delivery_key('LAWS0024', 'A6U', 'T1/2', '2025'), 'Law A', []),
+            new delivery(new delivery_key('LAWS0099', 'A7P', 'T1/2', '2025'), 'Law B', []),
+        ]);
+        $store = new db_student_delivery_store();
+        // The student belongs to no delivery.
+        $checker = $this->stub_checker([]);
+
+        $service = new delivery_service($source, $store, $checker);
+        $resolved = $service->resolve_student_deliveries(11, 22);
+
+        $this->assertSame([], $resolved);
+        $this->assertSame([], $store->find(11, 22));
+    }
+
+    /**
+     * An empty result is negatively cached, so a repeat visit skips the live resolver and its API.
+     *
+     * @covers \local_sitsgradepush\delivery\student_delivery_resolver::resolve
+     * @return void
+     */
+    public function test_negative_result_cached_skips_live_resolve_on_repeat(): void {
+        $this->resetAfterTest();
+
+        // The source is queried exactly once across both visits: the second is a negative-cache hit.
+        $source = $this->createMock(portico_delivery_source::class);
+        $source->expects($this->once())
+            ->method('get_course_deliveries')
+            ->willReturn([
+                new delivery(new delivery_key('LAWS0024', 'A6U', 'T1/2', '2025'), 'Law A', []),
+                new delivery(new delivery_key('LAWS0099', 'A7P', 'T1/2', '2025'), 'Law B', []),
+            ]);
+        // The student belongs to no delivery.
+        $checker = $this->stub_checker([]);
+
+        $service = new delivery_service($source, new db_student_delivery_store(), $checker);
+
+        // First visit finds nothing stored, runs the live resolver and caches the empty result;
+        // the second visit is served straight from the negative cache, so the live resolver does
+        // not run again. Both visits return empty, which these assertions confirm. The "runs only
+        // once" guarantee itself is enforced by the expects($this->once()) expectation above:
+        // PHPUnit fails the test at teardown if the second visit re-queried the source.
+        $this->assertSame([], $service->resolve_student_deliveries(11, 22));
+        $this->assertSame([], $service->resolve_student_deliveries(11, 22));
+    }
+
+    /**
+     * A resolved result is persisted, so a repeat visit is served from the durable store.
+     *
+     * @covers \local_sitsgradepush\delivery\student_delivery_resolver::resolve
+     * @return void
+     */
+    public function test_positive_result_served_from_store_on_repeat(): void {
+        $this->resetAfterTest();
+
+        $keyb = new delivery_key('LAWS0099', 'A7P', 'T1/2', '2025');
+        // A resolved (non-empty) result is persisted, so the second visit is served from the durable
+        // store and the live source is consulted only once.
+        $source = $this->createMock(portico_delivery_source::class);
+        $source->expects($this->once())
+            ->method('get_course_deliveries')
+            ->willReturn([
+                new delivery(new delivery_key('LAWS0024', 'A6U', 'T1/2', '2025'), 'Law A', []),
+                new delivery($keyb, 'Law B', []),
+            ]);
+        // The student belongs only to delivery B.
+        $checker = $this->stub_checker([$keyb->key()]);
+
+        $service = new delivery_service($source, new db_student_delivery_store(), $checker);
+
+        $this->assertSame($keyb->key(), $service->resolve_student_deliveries(11, 22)[0]->key());
+        $this->assertSame($keyb->key(), $service->resolve_student_deliveries(11, 22)[0]->key());
+    }
+
+    /**
+     * When the service is disabled, both entry points return empty without touching the source.
+     *
+     * @covers ::is_enabled
+     * @covers ::get_course_deliveries
+     * @covers ::resolve_student_deliveries
+     * @return void
+     */
+    public function test_disabled_service_returns_empty_without_querying_source(): void {
+        $this->resetAfterTest();
+
+        set_config('delivery_resolution_enabled', '0', 'local_sitsgradepush');
+
+        // Neither the source nor the membership checker is consulted while disabled.
+        $source = $this->createMock(portico_delivery_source::class);
+        $source->expects($this->never())->method('get_course_deliveries');
+        $checker = $this->createMock(sits_membership_checker::class);
+        $checker->expects($this->never())->method('is_member');
+
+        $service = new delivery_service($source, new db_student_delivery_store(), $checker);
+
+        $this->assertFalse(delivery_service::is_enabled());
+        $this->assertSame([], $service->get_course_deliveries(11));
+        $this->assertSame([], $service->resolve_student_deliveries(11, 22));
+    }
+
+    /**
+     * Build a source stub returning the given deliveries for any course.
+     *
+     * @param delivery[] $deliveries
+     * @return portico_delivery_source
+     */
+    private function stub_source(array $deliveries): portico_delivery_source {
+        $source = $this->createMock(portico_delivery_source::class);
+        $source->method('get_course_deliveries')->willReturn($deliveries);
+        return $source;
+    }
+
+    /**
+     * Build a membership checker stub reporting membership for the given delivery keys only.
+     *
+     * @param string[] $memberkeys
+     * @return sits_membership_checker
+     */
+    private function stub_checker(array $memberkeys): sits_membership_checker {
+        $checker = $this->createMock(sits_membership_checker::class);
+        $checker->method('is_member')->willReturnCallback(
+            fn(int $userid, delivery $delivery): bool => in_array($delivery->key->key(), $memberkeys, true)
+        );
+        return $checker;
+    }
+}

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_sitsgradepush';
 $plugin->release = '0.1.0';
-$plugin->version = 2026022000;
+$plugin->version = 2026062900;
 $plugin->requires = 2024042200;
 $plugin->maturity = MATURITY_ALPHA;
 $plugin->dependencies = [


### PR DESCRIPTION
- Resolve which SITS module delivery a student belongs to in multi-delivery courses, via portico module occurrences and the SITS get-students API.
- Persist confirmed student-to-delivery mappings in the new local_sitsgradepush_stuenrol table so repeat resolutions skip the live SITS check.
- Negatively cache "no delivery" results for a day so repeat page visits for unmatched students don't re-query the API.


