### PR TITLE
CTP-6604 Fix CURLOPT_SSL_VERIFYHOST value

### DIFF
--- a/apiclients/stutalkdirect/lib.php
+++ b/apiclients/stutalkdirect/lib.php
@@ -99,7 +99,7 @@ class stutalkdirect extends client {
 
             $curlclient = curl_init();
             curl_setopt($curlclient, CURLOPT_CONNECTTIMEOUT, 30);
-            curl_setopt($curlclient, CURLOPT_SSL_VERIFYHOST, true);
+            curl_setopt($curlclient, CURLOPT_SSL_VERIFYHOST, 2);
             curl_setopt($curlclient, CURLOPT_SSL_VERIFYPEER, true);
             curl_setopt($curlclient, CURLOPT_URL, $request->get_endpoint_url_with_params());
             curl_setopt($curlclient, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
PHPdocs say valid values for CURLOPT_SSL_VERIFYHOST are 0 and 2 and "1 should not be used". See
https://www.php.net/manual/en/curl.constants.php#constant.curlopt-ssl-verifyhost


